### PR TITLE
Oppdatere grunnbeløpet for mai 2019

### DIFF
--- a/src/main/kotlin/no/nav/helse/oppslag/Grunnbeløp.kt
+++ b/src/main/kotlin/no/nav/helse/oppslag/Grunnbeløp.kt
@@ -17,7 +17,8 @@ fun Grunnbeløp.gjelderFor(dato: LocalDate): Boolean {
 }
 
 val grunnbeløpListe: Set<Grunnbeløp> = setOf(
-        Grunnbeløp(of(2018, MAY, 1), MAX, 96883L),
+        Grunnbeløp(of(2019, MAY, 1), MAX, 99858L),
+        Grunnbeløp(of(2018, MAY, 1), of(2019, APRIL, 30), 96883L),
         Grunnbeløp(of(2017, MAY, 1), of(2018, APRIL, 30), 93634L),
         Grunnbeløp(of(2016, MAY, 1), of(2017, APRIL, 30), 92576L),
         Grunnbeløp(of(2015, MAY, 1), of(2016, APRIL, 30), 90068L)

--- a/src/test/kotlin/no/nav/helse/oppslag/GrunnbeløpTest.kt
+++ b/src/test/kotlin/no/nav/helse/oppslag/GrunnbeløpTest.kt
@@ -24,7 +24,8 @@ class GrunnbeløpTest {
 
     @Test
     fun ` Nyeste innslag i Grunnbeløpslista må oppdateres jevnlig `() {
-        //Nytt grunnbeløp bør være klart til 1. juni hvert år
+        // Nytt grunnbeløp bør være klart til 1. juni hvert år
+        // Sjekk https://www.nav.no/no/NAV+og+samfunn/Kontakt+NAV/Utbetalinger/Grunnbelopet+i+folketrygden
         assert(grunnbeløpListe.maxBy { it.fom }!!.fom.plusYears(1).plusMonths(1)).isGreaterThan(LocalDate.now())
     }
 

--- a/src/test/kotlin/no/nav/helse/oppslag/GrunnbeløpTest.kt
+++ b/src/test/kotlin/no/nav/helse/oppslag/GrunnbeløpTest.kt
@@ -3,8 +3,10 @@ package no.nav.helse.oppslag
 import assertk.assert
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isGreaterThan
 import assertk.assertions.isTrue
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 import java.time.LocalDate.of
 import java.time.Month
 
@@ -21,10 +23,23 @@ class GrunnbeløpTest {
     }
 
     @Test
-    fun ` Skal returnere grunnbeløp på 96883 for måned mai 2019 `() {
+    fun ` Nyeste innslag i Grunnbeløpslista må oppdateres jevnlig `() {
+        //Nytt grunnbeløp bør være klart til 1. juni hvert år
+        assert(grunnbeløpListe.maxBy { it.fom }!!.fom.plusYears(1).plusMonths(1)).isGreaterThan(LocalDate.now())
+    }
 
-        assert(getGrunnbeløpForDato(of(2019, Month.MAY, 1))).isEqualTo(96883L)
-        assert(getGrunnbeløpForDato(of(2019, Month.MAY, 31))).isEqualTo(96883L)
+    @Test
+    fun ` Skal returnere grunnbeløp på 99858 for måned april 2020 `() {
+
+        assert(getGrunnbeløpForDato(of(2020, Month.APRIL, 1))).isEqualTo(99858L)
+        assert(getGrunnbeløpForDato(of(2020, Month.APRIL, 30))).isEqualTo(99858L)
+    }
+
+    @Test
+    fun ` Skal returnere grunnbeløp på 99858 for måned mai 2019 `() {
+
+        assert(getGrunnbeløpForDato(of(2019, Month.MAY, 1))).isEqualTo(99858L)
+        assert(getGrunnbeløpForDato(of(2019, Month.MAY, 31))).isEqualTo(99858L)
     }
 
     @Test


### PR DESCRIPTION
og gjeninngføre testen som knekker når grunnbeløp burde vært oppdatert,
men nå med litt lengre frist.