### PR TITLE
Feilfiks maksdato

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     compile("no.nav.helse.sykepenger.lovverk:sykepenger-beregning:2018-12-20-101.8ef150a")
     compile("no.nav:nare:dfe6569")
 
-    compile("no.nav.helse:maksdato:ae7c5ad")
+    compile("no.nav.helse:maksdato:89af124")
     compile("no.nav:nare-prometheus:0b41ab4")
     compile("com.github.kittinunf.fuel:fuel:$fuelVersion")
 

--- a/src/main/kotlin/no/nav/helse/fastsetting/Maksdato.kt
+++ b/src/main/kotlin/no/nav/helse/fastsetting/Maksdato.kt
@@ -21,7 +21,7 @@ fun vurderMaksdato(
                     førsteSykepengedag = førsteSykepengedag,
                     personensAlder = alder.fastsattVerdi,
                     yrkesstatus = yrkesstatus,
-                    tidligerePerioder = sykepengehistorikk.map { Tidsperiode(it.fom, it.tom) }.sortedByDescending { it.tom }
+                    tidligerePerioder = sykepengehistorikk.map { Tidsperiode(it.fom, it.tom) }
             )
             val beregnetMaksdato = maksdato(grunnlag)
 

--- a/src/main/kotlin/no/nav/helse/fastsetting/Maksdato.kt
+++ b/src/main/kotlin/no/nav/helse/fastsetting/Maksdato.kt
@@ -25,9 +25,10 @@ fun vurderMaksdato(
             )
             val beregnetMaksdato = maksdato(grunnlag)
 
-            if (beregnetMaksdato.dato < sisteSykepengedag)
+            if (beregnetMaksdato.dato.isBefore(sisteSykepengedag))
+                // § 8-12. Antall sykepengedager er brukt opp eller blir det i sykepengeperioden. Kan være tilfeller der de likevel skal få utbetalt sykepenger (f.eks i deler av perioden)
                 Vurdering.Uavklart(
-                        årsak = Vurdering.Uavklart.Årsak.FALLER_UTENFOR_MVP, begrunnelse = "Maksdato er tidligere enn siste sykdomsdag, " + beregnetMaksdato.begrunnelse, grunnlag = grunnlag)
+                        årsak = Vurdering.Uavklart.Årsak.KREVER_SKJØNNSMESSIG_VURDERING, begrunnelse = "Maksdato er tidligere enn siste sykdomsdag, " + beregnetMaksdato.begrunnelse, grunnlag = grunnlag)
             else
                 Vurdering.Avklart(
                         fastsattVerdi = beregnetMaksdato.dato,

--- a/src/main/kotlin/no/nav/helse/fastsetting/Vurdering.kt
+++ b/src/main/kotlin/no/nav/helse/fastsetting/Vurdering.kt
@@ -97,6 +97,7 @@ fun vurderFakta(fakta: FaktagrunnlagResultat): Either<Behandlingsfeil, AvklarteF
     val maksdato = vurderMaksdato(alder,
             fakta.originalSøknad.startSyketilfelle,
             fakta.originalSøknad.fom,
+            fakta.originalSøknad.tom,
             Yrkesstatus.ARBEIDSTAKER,
             fakta.faktagrunnlag.sykepengehistorikk).also {
         if (it is Vurdering.Uavklart) {

--- a/src/test/kotlin/no/nav/helse/fastsetting/MaksdatoTest.kt
+++ b/src/test/kotlin/no/nav/helse/fastsetting/MaksdatoTest.kt
@@ -1,0 +1,72 @@
+package no.nav.helse.fastsetting
+
+import no.nav.helse.*
+import no.nav.helse.oppslag.AnvistPeriodeDTO
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import java.time.LocalDate
+import java.time.LocalDate.of
+
+class MaksdatoTest {
+
+    @Test
+    fun `Søker med tilgjengelige sykepengedager skal få maksdato i fremtiden avklart`() {
+
+        val alderVurdering = Vurdering.Avklart(39, begrunnelse_p_8_51, Aldersgrunnlag(LocalDate.of(1978, 5, 14)), "SPA")
+        val fom = LocalDate.of(2019, 6, 14)
+        val startSyketilfelle = LocalDate.of(2019, 6, 14)
+        val tom = LocalDate.of(2019, 6, 28)
+        val vurdering = vurderMaksdato(alderVurdering,
+                startSyketilfelle, fom, tom,
+                Yrkesstatus.ARBEIDSTAKER,
+                sykepengehistorikkDerSykepengedagerIkkeErOppbrukt())
+
+        when (vurdering) {
+            is Vurdering.Uavklart -> fail("Vurdering skal være avklart, maksdato skal være 2020-04-13")
+            is Vurdering.Avklart -> assertThat(vurdering.fastsattVerdi).isEqualTo(LocalDate.of(2020, 4, 13))
+        }
+    }
+
+    @Test
+    fun `Søker uten tilgjengelige sykepengedager skal få maksdato uavklart`() {
+
+        val alderVurdering = Vurdering.Avklart(39, begrunnelse_p_8_51, Aldersgrunnlag(LocalDate.of(1978, 5, 14)), "SPA")
+        val fom = LocalDate.of(2019, 6, 14)
+        val startSyketilfelle = LocalDate.of(2019, 6, 14)
+        val tom = LocalDate.of(2019, 6, 28)
+        val vurdering = vurderMaksdato(alderVurdering,
+                startSyketilfelle, fom, tom,
+                Yrkesstatus.ARBEIDSTAKER,
+                sykepengehistorikkDerSykepengedagerErOppbrukt())
+
+        when (vurdering) {
+            is Vurdering.Avklart -> fail("Vurdering skal være uavklart")
+            is Vurdering.Uavklart -> assertThat(vurdering.årsak).isEqualTo(Vurdering.Uavklart.Årsak.FALLER_UTENFOR_MVP)
+        }
+    }
+
+    private fun sykepengehistorikkDerSykepengedagerErOppbrukt(): List<AnvistPeriodeDTO> =
+            listOf(AnvistPeriodeDTO(of(2018, 5, 9), of(2018, 5, 14)),
+                    AnvistPeriodeDTO(of(2018, 5, 15), of(2018, 6, 14)),
+                    AnvistPeriodeDTO(of(2018, 6, 5), of(2018, 6, 25)),
+                    AnvistPeriodeDTO(of(2018, 6, 26), of(2018, 7, 16)),
+                    AnvistPeriodeDTO(of(2018, 7, 17), of(2018, 8, 6)),
+                    AnvistPeriodeDTO(of(2018, 8, 7), of(2018, 8, 27)),
+                    AnvistPeriodeDTO(of(2018, 8, 28), of(2018, 9, 20)),
+                    AnvistPeriodeDTO(of(2018, 9, 21), of(2018, 10, 14)),
+                    AnvistPeriodeDTO(of(2018, 10, 15), of(2018, 11, 7)),
+                    AnvistPeriodeDTO(of(2018, 11, 8), of(2018, 12, 23)),
+                    AnvistPeriodeDTO(of(2018, 12, 24), of(2019, 1, 14)),
+                    AnvistPeriodeDTO(of(2019, 1, 15), of(2019, 2, 14)),
+                    AnvistPeriodeDTO(of(2019, 2, 15), of(2019, 3, 11)),
+                    AnvistPeriodeDTO(of(2019, 3, 12), of(2019, 3, 31)),
+                    AnvistPeriodeDTO(of(2019, 4, 15), of(2019, 4, 26)),
+                    AnvistPeriodeDTO(of(2019, 4, 27), of(2019, 5, 3)),
+                    AnvistPeriodeDTO(of(2019, 5, 10), of(2019, 5, 14)))
+
+    private fun sykepengehistorikkDerSykepengedagerIkkeErOppbrukt(): List<AnvistPeriodeDTO> =
+            listOf(AnvistPeriodeDTO(of(2019, 2, 15), of(2019, 3, 11)),
+                    AnvistPeriodeDTO(of(2019, 3, 12), of(2019, 3, 31)))
+
+}

--- a/src/test/kotlin/no/nav/helse/fastsetting/MaksdatoTest.kt
+++ b/src/test/kotlin/no/nav/helse/fastsetting/MaksdatoTest.kt
@@ -42,7 +42,7 @@ class MaksdatoTest {
 
         when (vurdering) {
             is Vurdering.Avklart -> fail("Vurdering skal være uavklart")
-            is Vurdering.Uavklart -> assertThat(vurdering.årsak).isEqualTo(Vurdering.Uavklart.Årsak.FALLER_UTENFOR_MVP)
+            is Vurdering.Uavklart -> assertThat(vurdering.årsak).isEqualTo(Vurdering.Uavklart.Årsak.KREVER_SKJØNNSMESSIG_VURDERING)
         }
     }
 


### PR DESCRIPTION
Returnerer Vurdering.Uavklart når maksdato er tidligere enn siste sykepengedag.
Legger til tester for maksdato.