### PR TITLE
Filtrerer bort søknader om utlandsopphold / frilansere tidligere

### DIFF
--- a/src/main/kotlin/no/nav/helse/behandling/MVPFilter.kt
+++ b/src/main/kotlin/no/nav/helse/behandling/MVPFilter.kt
@@ -8,7 +8,7 @@ fun FaktagrunnlagResultat.mvpFilter(): Either<Behandlingsfeil, FaktagrunnlagResu
     val mvpKriterier = listOf(
             sjekkSvarISøknaden(sakskompleks.søknader[0]),
             vurderMVPKriterierForMedlemskap(faktagrunnlag.tps),
-            vurderMVPKriterierForOpptjeningstid(sakskompleks.søknader[0].arbeidsgiver!!, faktagrunnlag.arbeidInntektYtelse.arbeidsforhold),
+            vurderMVPKriterierForOpptjeningstid(sakskompleks.søknader[0].arbeidsgiver, faktagrunnlag.arbeidInntektYtelse.arbeidsforhold),
             vurderMVPKriterierForSykepengegrunnlaget(sakskompleks, faktagrunnlag.beregningsperiode, faktagrunnlag.sammenligningsperiode),
             vurderMVPKriterierForAndreYtelser(faktagrunnlag.arbeidInntektYtelse.ytelser, faktagrunnlag.ytelser)
     )

--- a/src/main/kotlin/no/nav/helse/behandling/Oppslag.kt
+++ b/src/main/kotlin/no/nav/helse/behandling/Oppslag.kt
@@ -45,7 +45,7 @@ class Oppslag(val sparkelBaseUrl: String, val stsClient: StsRestClient) {
 
     private fun Sakskompleks.markerFeil(ex: Throwable) = Behandlingsfeil.registerFeil(ex, this)
     private fun Sakskompleks.hentPerson() = PersonOppslag(sparkelBaseUrl, stsClient).hentTPSData(this)
-    private fun Sakskompleks.hentBeregningsgrunnlag() = Inntektsoppslag(sparkelBaseUrl, stsClient).hentBeregningsgrunnlag(aktørId, orgnummer!!, startSyketilfelle.minusMonths(3), startSyketilfelle.minusMonths(1))
+    private fun Sakskompleks.hentBeregningsgrunnlag() = Inntektsoppslag(sparkelBaseUrl, stsClient).hentBeregningsgrunnlag(aktørId, orgnummer, startSyketilfelle.minusMonths(3), startSyketilfelle.minusMonths(1))
     private fun Sakskompleks.hentSammenligningsgrunnlag() = Inntektsoppslag(sparkelBaseUrl, stsClient).hentSammenligningsgrunnlag(aktørId, startSyketilfelle.minusYears(1), startSyketilfelle.minusMonths(1))
     private fun Sakskompleks.hentArbeidInntektYtelse() = ArbeidInntektYtelseOppslag(sparkelBaseUrl, stsClient).hentArbeidInntektYtelse(this)
     private fun Sakskompleks.hentSykepengehistorikk() = SykepengehistorikkOppslag(sparkelBaseUrl, stsClient).hentSykepengehistorikk(aktørId, startSyketilfelle)

--- a/src/main/kotlin/no/nav/helse/behandling/Sakskompleks.kt
+++ b/src/main/kotlin/no/nav/helse/behandling/Sakskompleks.kt
@@ -25,7 +25,7 @@ data class Sakskompleks(val jsonNode: JsonNode) {
     val sykmeldinger get() = jsonNode["sykmeldinger"].map { SykmeldingMessage(it) }
     val søknader get() = jsonNode["søknader"].map { Sykepengesøknad(it) }
     val inntektsmeldinger get() = jsonNode["inntektsmeldinger"].map { Inntektsmelding(it) }
-    val orgnummer get() = jsonNode["orgnummer"]?.asText()
+    val orgnummer get() = jsonNode["orgnummer"].asText()
     val startSyketilfelle get() = jsonNode["syketilfelleStartdato"].safelyUnwrapDate()!!
     val sluttSyketilfelle get() = jsonNode["syketilfelleSluttdato"].safelyUnwrapDate()!!
 }

--- a/src/main/kotlin/no/nav/helse/behandling/søknad/Sykepengesøknad.kt
+++ b/src/main/kotlin/no/nav/helse/behandling/søknad/Sykepengesøknad.kt
@@ -36,14 +36,10 @@ data class Sykepengesøknad(val jsonNode: JsonNode) {
 
     val arbeidsgiver
         get() = with(jsonNode.path("arbeidsgiver")) {
-            if (isNull) {
-                null
-            } else {
-                ArbeidsgiverFraSøknad(
-                    navn = get("navn").textValue(),
-                    orgnummer = get("orgnummer").textValue()
-                )
-            }
+            ArbeidsgiverFraSøknad(
+                navn = get("navn").textValue(),
+                orgnummer = get("orgnummer").textValue()
+            )
         }
 
     val soktUtenlandsopphold get() = jsonNode.get("soktUtenlandsopphold").booleanValue()
@@ -127,7 +123,7 @@ fun Sykepengesøknad.tilSakskompleks(): Sakskompleks =
                 "sykmeldinger" to emptyList<Sykmelding>(),
                 "søknader" to listOf(this),
                 "inntektsmeldinger" to emptyList<Inntektsmelding>(),
-                "orgnummer" to arbeidsgiver?.orgnummer,
+                "orgnummer" to arbeidsgiver.orgnummer,
                 "syketilfelleStartdato" to startSyketilfelle,
                 "syketilfelleSluttdato" to tom
             )

--- a/src/main/kotlin/no/nav/helse/fastsetting/Arbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/helse/fastsetting/Arbeidsforhold.kt
@@ -42,7 +42,7 @@ fun vurderArbeidsforhold(fakta : FaktagrunnlagResultat) : Vurdering<Arbeidsforho
     return when {
         arbeidsforholdFakta.none {
             it.arbeidsgiver.identifikator == fakta.sakskompleks.orgnummer
-        } -> Uavklart(Uavklart.Årsak.HAR_IKKE_DATA, "Ingen arbeidsforhold hos aktuell arbeidsgiver", "Søker har ikke arbeidsforhold hos ${fakta.sakskompleks.søknader[0].arbeidsgiver!!.navn}", arbeidsforholdFakta)
-        else -> Vurdering.Avklart(arbeidsforholdFakta.first { it.arbeidsgiver.identifikator == fakta.sakskompleks.orgnummer }, "Søker har et arbeidsforhold hos ${fakta.sakskompleks.søknader[0].arbeidsgiver!!.navn}", arbeidsforholdFakta, "SPA")
+        } -> Uavklart(Uavklart.Årsak.HAR_IKKE_DATA, "Ingen arbeidsforhold hos aktuell arbeidsgiver", "Søker har ikke arbeidsforhold hos ${fakta.sakskompleks.søknader[0].arbeidsgiver.navn}", arbeidsforholdFakta)
+        else -> Vurdering.Avklart(arbeidsforholdFakta.first { it.arbeidsgiver.identifikator == fakta.sakskompleks.orgnummer }, "Søker har et arbeidsforhold hos ${fakta.sakskompleks.søknader[0].arbeidsgiver.navn}", arbeidsforholdFakta, "SPA")
     }
 }

--- a/src/main/kotlin/no/nav/helse/oppslag/arbeidinntektytelse/ArbeidInntektYtelseOppslag.kt
+++ b/src/main/kotlin/no/nav/helse/oppslag/arbeidinntektytelse/ArbeidInntektYtelseOppslag.kt
@@ -4,7 +4,6 @@ import arrow.core.Try
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.kittinunf.fuel.httpGet
 import no.nav.helse.behandling.Sakskompleks
-import no.nav.helse.behandling.søknad.Sykepengesøknad
 import no.nav.helse.oppslag.AktørId
 import no.nav.helse.oppslag.StsRestClient
 import no.nav.helse.oppslag.arbeidinntektytelse.dto.ArbeidInntektYtelseDTO

--- a/src/main/kotlin/no/nav/helse/probe/SaksBehandlingsProbe.kt
+++ b/src/main/kotlin/no/nav/helse/probe/SaksBehandlingsProbe.kt
@@ -44,6 +44,11 @@ class SaksbehandlingProbe(env: Environment) {
                 .labelNames("faktum")
                 .help("Hvilke faktum klarer vi ikke fastsette")
                 .register()
+        private val søknadFiltrertBortPgaTypeCounter = Counter.build()
+            .name("soknad_filtrert_bort_pga_type")
+            .labelNames("type")
+            .help("Antall søknader som blir filtrert bort fordi vi ikke støtter typen")
+            .register()
 
     }
 
@@ -63,6 +68,11 @@ class SaksbehandlingProbe(env: Environment) {
     fun mottattSøknad(søknadId: String, søknadStatus: String, søknadType: String) {
         sendMottattSykepengesøknadEvent(søknadId, søknadStatus, søknadType)
         mottattCounter.labels(søknadStatus, søknadType).inc()
+    }
+
+    fun filtrertBortSøknadPgaType(søknadId: String, søknadType: String) {
+        log.info("Søknad $søknadId er filtrert bort pga den har type: $søknadType")
+        søknadFiltrertBortPgaTypeCounter.labels(søknadType).inc()
     }
 
     fun mottattSøknadUansettStatusOgType(søknadId: String) {

--- a/src/test/kotlin/no/nav/helse/behandling/mvp/SykepengegrunnlagKtTest.kt
+++ b/src/test/kotlin/no/nav/helse/behandling/mvp/SykepengegrunnlagKtTest.kt
@@ -6,15 +6,12 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import no.nav.helse.EndToEndTest
 import no.nav.helse.behandling.Sakskompleks
 import no.nav.helse.oppslag.Inntekt
 import no.nav.helse.oppslag.Inntektsarbeidsgiver
 import no.nav.helse.readResource
-import no.nav.helse.sykepenger.beregning.Sykepengegrunnlag
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-
-import org.junit.jupiter.api.Assertions.*
 import java.math.BigDecimal
 import java.time.YearMonth
 

--- a/src/test/resources/søknader/utlandsopphold_sendt_nav.json
+++ b/src/test/resources/søknader/utlandsopphold_sendt_nav.json
@@ -1,0 +1,19 @@
+{
+  "id": "68da259c-ff7f-47cf-8fa0-c348ae95e220",
+  "aktorId": "1234567890123",
+  "sykmeldingId": null,
+  "soknadstype": "OPPHOLD_UTLAND",
+  "status": "SENDT",
+  "fom": null,
+  "tom": null,
+  "opprettetDato": "2019-06-01T00:00:00.000",
+  "innsendtDato": "2019-06-01",
+  "startSykeforlop": null,
+  "sykmeldingUtskrevet": null,
+  "arbeidsgiver": null,
+  "korrigerer": null,
+  "korrigertAv": null,
+  "arbeidssituasjon": null,
+  "soknadPerioder": [],
+  "sporsmal": null
+}


### PR DESCRIPTION
Disse søknadene er utenfor hva vi skal støtte i starten og de medfører en del kompleksitet da de ikke inneholder alle de feltene som brukes nedover. Derfor er det bedre å bare kaste dem ut i starten før vi begynner å mappe dem om for behandling. Da kan jeg også gjøre sakskompleks strengere på hva slags felter som er obligatoriske.